### PR TITLE
Trigger reconnect on modbus read failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="watlow",
-    version="0.2.3",
+    version="0.2.4",
     description="Python driver for Watlow EZ-Zone temperature controllers.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/watlow/util.py
+++ b/watlow/util.py
@@ -115,13 +115,10 @@ class AsyncioModbusClient(object):
         self.waiting = True
         try:
             return await asyncio.wait_for(future, timeout=self.timeout)
-        except asyncio.TimeoutError as e:
+        except (asyncio.TimeoutError, pymodbus.exceptions.ModbusIOException) as e:
             if self.open:
-                # This came from reading through the pymodbus@python3 source
-                # Problem was that the driver was not detecting disconnect
-                if hasattr(self, 'modbus'):
-                    self.client.protocol_lost_connection(self.modbus)
                 self.open = False
+                await self._connect()
             raise TimeoutError(e)
         except pymodbus.exceptions.ConnectionException as e:
             raise ConnectionError(e)


### PR DESCRIPTION
Periodically a connection to the RUI will start returning invalid responses.

```
Unable to decode response Modbus Error: Unknown response 65

03:51:06 PM CDT, 26 Aug 2020
ERROR default_exception_handler:1285
Exception in callback _SelectorSocketTransport._read_ready()
handle: <Handle _SelectorSocketTransport._read_ready()>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.6/asyncio/selector_events.py", line 721, in _read_ready
    self._protocol.data_received(data)
  File "/usr/local/lib/python3.6/site-packages/pymodbus/client/asynchronous/asyncio/__init__.py", line 189, in data_received
    self._dataReceived(data)
  File "/usr/local/lib/python3.6/site-packages/pymodbus/client/asynchronous/asyncio/__init__.py", line 136, in _dataReceived
    self.framer.processIncomingPacket(data, self._handleResponse, unit=unit)
  File "/usr/local/lib/python3.6/site-packages/pymodbus/framer/socket_framer.py", line 153, in processIncomingPacket
    self._process(callback)
  File "/usr/local/lib/python3.6/site-packages/pymodbus/framer/socket_framer.py", line 175, in _process
    raise ModbusIOException("Unable to decode request")
pymodbus.exceptions.ModbusIOException: Modbus Error: [Input/Output] Unable to decode request
```

I'm not sure if "65" was the function code or an exception code or what. 65 does not seem to correspond to any valid Modbus code. The error seems to persist until the connection is refreshed.