### PR TITLE
Allow for higher temperatures to be set. Closes #5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="watlow",
-    version="0.2.5",
+    version="0.2.6",
     description="Python driver for Watlow EZ-Zone temperature controllers.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/watlow/driver.py
+++ b/watlow/driver.py
@@ -103,8 +103,6 @@ class TemperatureController(object):
 
     def set(self, setpoint):
         """Set the setpoint temperature, in C."""
-        if not 10 <= setpoint <= 220:
-            raise ValueError("Setpoint must be between 10°C and 200°C.")
         body = self.commands['set']['body'] + struct.pack('>f', c_to_f(setpoint))
         checksum = struct.pack('<H', ~crc(body) & 0xffff)
         response = self._write_and_read(
@@ -153,13 +151,13 @@ class TemperatureController(object):
 class Gateway(AsyncioModbusClient):
     """Watlow communication using their EZ-Zone Modbus Gateway."""
 
-    def __init__(self, address, timeout=1, modbus_offset=5000):
+    def __init__(self, address, timeout=1, modbus_offset=5000, max_temp=220):
         """Open connection to gateway."""
         super().__init__(address, timeout)
         self.modbus_offset = modbus_offset
         self.actual_temp_address = 360
         self.setpoint_address = 2160
-        self.setpoint_range = (10, 220)
+        self.setpoint_range = (10, max_temp)
 
     async def get(self, zone: int):
         """Get oven data for a zone.


### PR DESCRIPTION
I removed the check entirely from the RS-485 driver and made the upper limit configurable on the Gateway driver