### PR TITLE
Reconnect on both TimeoutError and ConnectionError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as in_file:
 
 setup(
     name="watlow",
-    version="0.5.0",
+    version="0.5.1",
     description="Python driver for Watlow EZ-Zone temperature controllers.",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/watlow/util.py
+++ b/watlow/util.py
@@ -124,6 +124,8 @@ class AsyncioModbusClient(object):
                     self.client.protocol_lost_connection(self.modbus)
                 raise TimeoutError(e)
             except pymodbus.exceptions.ConnectionException as e:
+                if self.client.connected and hasattr(self, 'modbus'):
+                    self.client.protocol_lost_connection(self.modbus)
                 raise ConnectionError(e)
 
     async def _close(self):


### PR DESCRIPTION
Extension of #15, which didn't quite work

```python
  File "/usr/local/lib/python3.10/site-packages/watlow/util.py", line 68, in read_registers
    r = await self._request('read_holding_registers', address, count)
  File "/usr/local/lib/python3.10/site-packages/watlow/util.py", line 127, in _request
    raise ConnectionError(e)
ConnectionError: Modbus Error: [Connection] Connection lost during request
```

