### PR TITLE
Generalize CRC calculation and add new serial commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Install parameters for CLI and python import."""
 from sys import version_info
+
 from setuptools import setup
 
 if version_info < (3, 7):

--- a/watlow/__init__.py
+++ b/watlow/__init__.py
@@ -3,8 +3,8 @@
 Distributed under the GNU General Public License v2
 Copyright (C) 2019 NuMat Technologies
 """
-from watlow.driver import TemperatureController, Gateway
 from watlow import mock  # noqa: F401
+from watlow.driver import Gateway, TemperatureController
 
 
 def command_line(args=None):

--- a/watlow/driver.py
+++ b/watlow/driver.py
@@ -1,4 +1,5 @@
 """Drivers for Watlow EZ-Zone temperature controllers."""
+import logging
 import re
 import struct
 from binascii import unhexlify
@@ -133,11 +134,13 @@ class TemperatureController(object):
             raise IOError("Could not communicate with Watlow.")
         self.connection.flush()
         try:
+            logging.debug('Formatted Request: ' + str(bytes.hex(request)))
             self.connection.write(request)
             response = self.connection.read(length)
         except serial.serialutil.SerialException:
             return self._write_and_read(request, length, check, retries - 1)
         match = check.match(bytes.hex(response))
+        logging.debug('Formatted Response: ' + str(bytes.hex(response)))
         if not match:
             return self._write_and_read(request, length, check, retries - 1)
         value = match.group(1)

--- a/watlow/driver.py
+++ b/watlow/driver.py
@@ -1,7 +1,7 @@
 """Drivers for Watlow EZ-Zone temperature controllers."""
+import re
 import struct
 from binascii import unhexlify
-import re
 
 import crcmod
 import serial

--- a/watlow/mock.py
+++ b/watlow/mock.py
@@ -1,8 +1,8 @@
 """Mock Watlow interface. Use for debugging systems."""
 
 import asyncio
-from random import random
 from copy import deepcopy
+from random import random
 from unittest.mock import MagicMock
 
 from watlow.driver import Gateway as realGateway


### PR DESCRIPTION
This PR integrates work from @dougpopeney to extend the serial ("standard bus") functionality.  Thanks!

 - [x] Implement both CRC8 and CRC16 functions
 - [x] Calculate header CRC dynamically instead of hardcoding
 - [x] Add a bit of logging
~~Extend get/set to multiple new commands~~

Closes #19 
