### PR TITLE
Pymodbus 3.3 test - potentially fix broken reconnects in 3.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,9 +46,9 @@ jobs:
     - name: Lint with ruff
       run: |
         ruff .
-    # - name: Check types with mypy
-    #   run: |
-    #      mypy watlow
+    - name: Check types with mypy
+      run: |
+         mypy watlow
     - name: Pytest
       run: |
         pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,8 @@
 [mypy]
 check_untyped_defs = True
 
+[mypy-pymodbus.*]
+ignore_missing_imports = True
+
 [tool:pytest]
 addopts = --cov=watlow

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             'pytest-cov',
             'pytest-asyncio',
             'ruff==0.0.271',
+            'types-pyserial',
         ],
     },
     entry_points={

--- a/watlow/util.py
+++ b/watlow/util.py
@@ -127,6 +127,7 @@ class AsyncioModbusClient:
                     future = getattr(self.client.protocol, method)  # type: ignore
                 return await future(*args, **kwargs)
             except (asyncio.TimeoutError, pymodbus.exceptions.ConnectionException):
+                self.client._launch_reconnect()
                 raise TimeoutError("Not connected to Watlow gateway")
 
     async def _close(self) -> None:

--- a/watlow/util.py
+++ b/watlow/util.py
@@ -127,7 +127,6 @@ class AsyncioModbusClient:
                     future = getattr(self.client.protocol, method)  # type: ignore
                 return await future(*args, **kwargs)
             except (asyncio.TimeoutError, pymodbus.exceptions.ConnectionException):
-                self.client._launch_reconnect()
                 raise TimeoutError("Not connected to Watlow gateway")
 
     async def _close(self) -> None:


### PR DESCRIPTION
This supercedes https://github.com/numat/watlow/pull/18

Working towards fixing [the lab oven disconnects](https://app.asana.com/0/1160839521206525/1203403088052342/f).

https://github.com/numat/watlow/tree/183c7ae5eff3cb6b2b952f93c3440f16d42ce8e7 has been running now for 48 hours without incident, and has successfully reconnected several times.  This PR is a cleaned up version of that commit.

I don't think 7760b9b1d4d1a8b34cf5ebbb5f375b2c621a4507 has a use, but am keeping it around in the history.  I expect the lab ovens work without it (i.e. revert e8ea56754031b9782981b8908f1e40c37a6b0256 is applied).