### PR TITLE
Remove lock on connect

### DIFF
--- a/watlow/util.py
+++ b/watlow/util.py
@@ -49,14 +49,13 @@ class AsyncioModbusClient:
 
     async def _connect(self):
         """Start asynchronous reconnect loop."""
-        async with self.lock:
-            try:
-                if self.pymodbus30plus:
-                    await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
-                else:  # 2.4.x - 2.5.x
-                    await self.client.start(self.ip)  # type: ignore
-            except Exception:
-                raise OSError(f"Could not connect to '{self.ip}'.")
+        try:
+            if self.pymodbus30plus:
+                await asyncio.wait_for(self.client.connect(), timeout=self.timeout)  # 3.x
+            else:  # 2.4.x - 2.5.x
+                await self.client.start(self.ip)  # type: ignore
+        except Exception:
+            raise OSError(f"Could not connect to '{self.ip}'.")
 
     async def read_coils(self, address, count):
         """Read modbus output coils (0 address prefix)."""


### PR DESCRIPTION
See https://github.com/numat/clickplc/pull/86

Lock on `_connect` seems to be redundant, since `_request` already awaits the `connectTask`.
